### PR TITLE
refactor: rename `CGroup` to `Cgroup`

### DIFF
--- a/cgroup.go
+++ b/cgroup.go
@@ -35,7 +35,7 @@ type cgroupStatter interface {
 	memory(p Prefix) (*Result, error)
 }
 
-func (s *Statter) getCGroupStatter() (cgroupStatter, error) {
+func (s *Statter) getCgroupStatter() (cgroupStatter, error) {
 	isContainerized, err := s.IsContainerized()
 	if err != nil {
 		return nil, err
@@ -44,7 +44,7 @@ func (s *Statter) getCGroupStatter() (cgroupStatter, error) {
 		return nil, errNotContainerized
 	}
 
-	if s.isCGroupV2() {
+	if s.isCgroupV2() {
 		cgroupPath, err := currentProcCgroup(s.fs)
 		if err != nil {
 			return nil, xerrors.Errorf("get current cgroup: %w", err)
@@ -105,7 +105,7 @@ func (s *Statter) ContainerCPU() (*Result, error) {
 	return r, nil
 }
 
-func (s *Statter) isCGroupV2() bool {
+func (s *Statter) isCgroupV2() bool {
 	return s.cgroupV2Detector(s.fs)
 }
 

--- a/cgroup_linux.go
+++ b/cgroup_linux.go
@@ -4,7 +4,7 @@ import (
 	"syscall"
 )
 
-func isCGroupV2(path string) bool {
+func isCgroupV2(path string) bool {
 	var stat syscall.Statfs_t
 	if err := syscall.Statfs(path, &stat); err != nil {
 		return false

--- a/cgroup_other.go
+++ b/cgroup_other.go
@@ -2,6 +2,6 @@
 
 package clistat
 
-func isCGroupV2(path string) bool {
+func isCgroupV2(_ string) bool {
 	return false
 }

--- a/cgroupv1.go
+++ b/cgroupv1.go
@@ -11,7 +11,7 @@ import (
 	"tailscale.com/types/ptr"
 )
 
-// Paths for CGroupV1.
+// Paths for CgroupV1.
 // Ref: https://www.kernel.org/doc/Documentation/cgroup-v1/cpuacct.txt
 const (
 	// CPU usage of all tasks in cgroup in nanoseconds.

--- a/cgroupv2.go
+++ b/cgroupv2.go
@@ -11,7 +11,7 @@ import (
 	"tailscale.com/types/ptr"
 )
 
-// Paths for CGroupV2.
+// Paths for CgroupV2.
 // Ref: https://docs.kernel.org/admin-guide/cgroup-v2.html
 const (
 	// Contains quota and period in microseconds separated by a space.

--- a/stat.go
+++ b/stat.go
@@ -193,7 +193,7 @@ func New(opts ...Option) (*Statter, error) {
 			<-time.After(d)
 		},
 		cgroupV2Detector: func(_ afero.Fs) bool {
-			return isCGroupV2(cgroupRootPath)
+			return isCgroupV2(cgroupRootPath)
 		},
 	}
 	for _, opt := range opts {
@@ -202,7 +202,7 @@ func New(opts ...Option) (*Statter, error) {
 
 	s.nproc = s.numCPU()
 
-	statter, err := s.getCGroupStatter()
+	statter, err := s.getCgroupStatter()
 	if err != nil && !errors.Is(err, errNotContainerized) {
 		return nil, xerrors.Errorf("get cgroup statter: %v", err)
 	}

--- a/stat_internal_test.go
+++ b/stat_internal_test.go
@@ -132,7 +132,7 @@ func TestStatter(t *testing.T) {
 		}
 	}
 
-	withIsCGroupV2 := func(state bool) Option {
+	withIsCgroupV2 := func(state bool) Option {
 		return func(s *Statter) {
 			s.cgroupV2Detector = func(_ afero.Fs) bool {
 				return state
@@ -143,7 +143,7 @@ func TestStatter(t *testing.T) {
 	// For container-specific measurements, everything we need
 	// can be read from the filesystem. We control the FS, so
 	// we control the data.
-	t.Run("CGroupV1", func(t *testing.T) {
+	t.Run("CgroupV1", func(t *testing.T) {
 		t.Parallel()
 
 		t.Run("ContainerCPU/Limit", func(t *testing.T) {
@@ -154,7 +154,7 @@ func TestStatter(t *testing.T) {
 				// Fake 1 second in ns of usage
 				mungeFS(t, fs, cgroupV1CPUAcctUsage, "100000000")
 			}
-			s, err := New(WithFS(fs), withWait(fakeWait), withIsCGroupV2(false))
+			s, err := New(WithFS(fs), withWait(fakeWait), withIsCgroupV2(false))
 			require.NoError(t, err)
 
 			cpu, err := s.ContainerCPU()
@@ -175,7 +175,7 @@ func TestStatter(t *testing.T) {
 				// Fake 1 second in ns of usage
 				mungeFS(t, fs, cgroupV1CPUAcctUsage, "100000000")
 			}
-			s, err := New(WithFS(fs), withNproc(2), withWait(fakeWait), withIsCGroupV2(false))
+			s, err := New(WithFS(fs), withNproc(2), withWait(fakeWait), withIsCgroupV2(false))
 			require.NoError(t, err)
 
 			cpu, err := s.ContainerCPU()
@@ -195,7 +195,7 @@ func TestStatter(t *testing.T) {
 				// Fake 1 second in ns of usage
 				mungeFS(t, fs, "/sys/fs/cgroup/cpuacct/cpuacct.usage", "100000000")
 			}
-			s, err := New(WithFS(fs), withNproc(2), withWait(fakeWait), withIsCGroupV2(false))
+			s, err := New(WithFS(fs), withNproc(2), withWait(fakeWait), withIsCgroupV2(false))
 			require.NoError(t, err)
 
 			cpu, err := s.ContainerCPU()
@@ -212,7 +212,7 @@ func TestStatter(t *testing.T) {
 			t.Parallel()
 
 			fs := initFS(t, fsContainerCgroupV1)
-			s, err := New(WithFS(fs), withNoWait, withIsCGroupV2(false))
+			s, err := New(WithFS(fs), withNoWait, withIsCgroupV2(false))
 			require.NoError(t, err)
 
 			mem, err := s.ContainerMemory(PrefixDefault)
@@ -229,7 +229,7 @@ func TestStatter(t *testing.T) {
 			t.Parallel()
 
 			fs := initFS(t, fsContainerCgroupV1NoLimit)
-			s, err := New(WithFS(fs), withNoWait, withIsCGroupV2(false))
+			s, err := New(WithFS(fs), withNoWait, withIsCgroupV2(false))
 			require.NoError(t, err)
 
 			mem, err := s.ContainerMemory(PrefixDefault)
@@ -245,7 +245,7 @@ func TestStatter(t *testing.T) {
 			t.Parallel()
 
 			fs := initFS(t, fsContainerCgroupV1DockerNoMemoryLimit)
-			s, err := New(WithFS(fs), withNoWait, withIsCGroupV2(false))
+			s, err := New(WithFS(fs), withNoWait, withIsCgroupV2(false))
 			require.NoError(t, err)
 
 			mem, err := s.ContainerMemory(PrefixDefault)
@@ -258,7 +258,7 @@ func TestStatter(t *testing.T) {
 		})
 	})
 
-	t.Run("CGroupV2", func(t *testing.T) {
+	t.Run("CgroupV2", func(t *testing.T) {
 		t.Parallel()
 
 		t.Run("ContainerCPU/Limit", func(t *testing.T) {
@@ -268,7 +268,7 @@ func TestStatter(t *testing.T) {
 			fakeWait := func(time.Duration) {
 				mungeFS(t, fs, filepath.Join(cgroupRootPath, cgroupV2Path, cgroupV2CPUStat), "usage_usec 100000")
 			}
-			s, err := New(WithFS(fs), withWait(fakeWait), withIsCGroupV2(true))
+			s, err := New(WithFS(fs), withWait(fakeWait), withIsCgroupV2(true))
 
 			require.NoError(t, err)
 			cpu, err := s.ContainerCPU()
@@ -288,7 +288,7 @@ func TestStatter(t *testing.T) {
 			fakeWait := func(time.Duration) {
 				mungeFS(t, fs, filepath.Join(cgroupRootPath, cgroupV2Path, cgroupV2CPUStat), "usage_usec 100000")
 			}
-			s, err := New(WithFS(fs), withNproc(2), withWait(fakeWait), withIsCGroupV2(true))
+			s, err := New(WithFS(fs), withNproc(2), withWait(fakeWait), withIsCgroupV2(true))
 			require.NoError(t, err)
 
 			cpu, err := s.ContainerCPU()
@@ -304,7 +304,7 @@ func TestStatter(t *testing.T) {
 			t.Parallel()
 
 			fs := initFS(t, fsContainerCgroupV2)
-			s, err := New(WithFS(fs), withNoWait, withIsCGroupV2(true))
+			s, err := New(WithFS(fs), withNoWait, withIsCgroupV2(true))
 			require.NoError(t, err)
 
 			mem, err := s.ContainerMemory(PrefixDefault)
@@ -321,7 +321,7 @@ func TestStatter(t *testing.T) {
 			t.Parallel()
 
 			fs := initFS(t, fsContainerCgroupV2NoLimit)
-			s, err := New(WithFS(fs), withNoWait, withIsCGroupV2(true))
+			s, err := New(WithFS(fs), withNoWait, withIsCgroupV2(true))
 			require.NoError(t, err)
 
 			mem, err := s.ContainerMemory(PrefixDefault)
@@ -343,7 +343,7 @@ func TestStatter(t *testing.T) {
 				fakeWait := func(time.Duration) {
 					mungeFS(t, fs, filepath.Join(cgroupRootPath, fsContainerCgroupV2KubernetesPath, cgroupV2CPUStat), "usage_usec 100000")
 				}
-				s, err := New(WithFS(fs), withWait(fakeWait), withIsCGroupV2(true))
+				s, err := New(WithFS(fs), withWait(fakeWait), withIsCgroupV2(true))
 				require.NoError(t, err)
 
 				cpu, err := s.ContainerCPU()
@@ -364,7 +364,7 @@ func TestStatter(t *testing.T) {
 				fakeWait := func(time.Duration) {
 					mungeFS(t, fs, filepath.Join(cgroupRootPath, fsContainerCgroupV2KubernetesPath, cgroupV2CPUStat), "usage_usec 100000")
 				}
-				s, err := New(WithFS(fs), withWait(fakeWait), withIsCGroupV2(true))
+				s, err := New(WithFS(fs), withWait(fakeWait), withIsCgroupV2(true))
 				require.NoError(t, err)
 
 				cpu, err := s.ContainerCPU()
@@ -384,7 +384,7 @@ func TestStatter(t *testing.T) {
 				fakeWait := func(time.Duration) {
 					mungeFS(t, fs, filepath.Join(cgroupRootPath, fsContainerCgroupV2KubernetesPath, cgroupV2CPUStat), "usage_usec 100000")
 				}
-				s, err := New(WithFS(fs), withWait(fakeWait), withIsCGroupV2(true))
+				s, err := New(WithFS(fs), withWait(fakeWait), withIsCgroupV2(true))
 				require.NoError(t, err)
 
 				cpu, err := s.ContainerCPU()
@@ -400,7 +400,7 @@ func TestStatter(t *testing.T) {
 				t.Parallel()
 
 				fs := initFS(t, fsContainerCgroupV2KubernetesWithLimits)
-				s, err := New(WithFS(fs), withNoWait, withIsCGroupV2(true))
+				s, err := New(WithFS(fs), withNoWait, withIsCgroupV2(true))
 				require.NoError(t, err)
 
 				mem, err := s.ContainerMemory(PrefixDefault)
@@ -419,7 +419,7 @@ func TestStatter(t *testing.T) {
 				fs := initFS(t, fsContainerCgroupV2Kubernetes)
 				mungeFS(t, fs, filepath.Join(cgroupRootPath, cgroupV2MemoryMaxBytes), "1073741824")
 
-				s, err := New(WithFS(fs), withNoWait, withIsCGroupV2(true))
+				s, err := New(WithFS(fs), withNoWait, withIsCgroupV2(true))
 				require.NoError(t, err)
 
 				mem, err := s.ContainerMemory(PrefixDefault)
@@ -436,7 +436,7 @@ func TestStatter(t *testing.T) {
 				t.Parallel()
 
 				fs := initFS(t, fsContainerCgroupV2Kubernetes)
-				s, err := New(WithFS(fs), withNoWait, withIsCGroupV2(true))
+				s, err := New(WithFS(fs), withNoWait, withIsCgroupV2(true))
 				require.NoError(t, err)
 
 				mem, err := s.ContainerMemory(PrefixDefault)
@@ -451,10 +451,10 @@ func TestStatter(t *testing.T) {
 	})
 }
 
-func TestCGroupV2Detection(t *testing.T) {
+func TestCgroupV2Detection(t *testing.T) {
 	t.Parallel()
 
-	hostISCGroupV2 := os.Getenv("CLISTAT_IS_CGROUPV2") == "yes"
+	hostIsCgroupV2 := os.Getenv("CLISTAT_IS_CGROUPV2") == "yes"
 
 	tests := []struct {
 		name string
@@ -477,8 +477,8 @@ func TestCGroupV2Detection(t *testing.T) {
 			s, err := New(WithFS(tt.fs))
 			require.NoError(t, err)
 
-			isCGroupV2 := s.cgroupV2Detector(s.fs)
-			assert.Equal(t, hostISCGroupV2, isCGroupV2)
+			isCgroupV2 := s.cgroupV2Detector(s.fs)
+			assert.Equal(t, hostIsCgroupV2, isCgroupV2)
 		})
 	}
 }


### PR DESCRIPTION
Rename all occurences but one to `Cgroup` instead of `CGroup`. `WithISCGroupV2` is an exported function (although it appears I must've removed usage of it in a recent commit), so we cannot rename/remove this without bumping the major version.