### PR TITLE
fix: handle extra colons in /proc/self/cgroup entries

### DIFF
--- a/cgroup.go
+++ b/cgroup.go
@@ -128,9 +128,9 @@ func currentProcCgroup(fs afero.Fs) (string, error) {
 	entries := strings.Split(strings.TrimSpace(string(data)), "\n")
 
 	for _, entry := range entries {
-		parts := strings.Split(strings.TrimSpace(entry), ":")
+		parts := strings.SplitN(strings.TrimSpace(entry), ":", 3)
 		if len(parts) != 3 {
-			return "", xerrors.Errorf("parse entry %v: %w", procSelfCgroup, err)
+			return "", xerrors.Errorf("parse entry %v: expected at least 3 colon-separated fields in %q", procSelfCgroup, entry)
 		}
 
 		if parts[0] == "0" {

--- a/cgroup_internal_test.go
+++ b/cgroup_internal_test.go
@@ -55,6 +55,22 @@ func TestCurrentProcCgroup(t *testing.T) {
 			expectPath: "/init.slice",
 		},
 		{
+			name:       "ExtraColonsInPath",
+			procFile:   `0::/system.slice/kubepods-burstable.slice:cri-containerd:d24f9cc`,
+			expectPath: "/system.slice/kubepods-burstable.slice:cri-containerd:d24f9cc",
+		},
+		{
+			name: "ExtraColonsInPathWithMixedHierarchy",
+			procFile: `1:net_cls:/init.slice
+0::/system.slice/kubepods.slice:cri-containerd:abc123`,
+			expectPath: "/system.slice/kubepods.slice:cri-containerd:abc123",
+		},
+		{
+			name:        "MalformedEntryTooFewFields",
+			procFile:    `0`,
+			expectError: "parse entry",
+		},
+		{
 			name:        "MissingHierarchy0",
 			procFile:    `1:net_cls:/`,
 			expectError: "no cgroup entry for hierarchy 0 found",


### PR DESCRIPTION
Fixes #34

## Problem

On some Kubernetes nodes, `/proc/self/cgroup` contains entries with extra colons in the path:

```
0::/system.slice/kubepods-burstable-pod72e25f20.slice:cri-containerd:d24f9cc...
```

`currentProcCgroup()` used `strings.Split(entry, ":")` which expected exactly 3 parts. Extra colons produced 4+ parts, causing a parse error that crashed the agent.

Additionally, the error message wrapped a nil `err` variable, producing `%!w(<nil>)` in logs.

## Fix

- Use `strings.SplitN(..., 3)` to limit splitting to 3 parts, preserving extra colons in the path field.
- Fix nil error wrapping in the parse error message to show the actual malformed entry.

## Tests

Added 3 test cases:
- Extra colons in path
- Extra colons with mixed cgroup hierarchy
- Malformed entry with too few fields